### PR TITLE
CMake: use aux_source_directory command to avoid writing the list of source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,19 @@ add_custom_command(
 
 add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-sign-compare -Werror)
 
-list(APPEND sources src/ast/action.cc src/ast/alternation.cc src/ast/capture.cc src/ast/code.cc src/ast/directive.cc src/ast/expand.cc src/ast/grammar.cc src/ast/group.cc src/ast/character_class.cc src/ast/node.cc src/ast/reference.cc src/ast/rule.cc src/ast/sequence.cc src/ast/string.cc src/ast/term.cc src/config.cc src/checker.cc src/log.cc src/main.cc src/optimizer.cc src/packcc_wrapper.c src/parser.cc src/utils.cc ${CMAKE_CURRENT_BINARY_DIR}/version.cc)
+###################################################
+
+set(sources ${CMAKE_CURRENT_BINARY_DIR}/version.cc)
+
+aux_source_directory(src/ast SRCS1)
+aux_source_directory(src     SRCS2)
+
+list(APPEND sources ${SRCS1})
+list(APPEND sources ${SRCS2})
+
+message(STATUS "sources=${sources}")
+
+###################################################
 
 add_library(common INTERFACE)
 target_include_directories(common BEFORE INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR}/packcc/src ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Reference: https://cmake.org/cmake/help/latest/command/aux_source_directory.html