### PR TITLE
Separate coverage action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,35 @@
+name: Check coverage
+
+on:
+  pull_request:
+    branches: [ master, devel ]
+
+jobs:
+  testing:
+    runs-on: ubuntu-24.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      CMAKE_BUILD_TYPE: Debug
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: recursive
+    - name: Install dependencies
+      shell: bash
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get -y --no-install-recommends -o APT::Immediate-Configure=false install cmake bats g++ gcovr lcov uncrustify
+    - name: Coverage
+      run: |
+        set -ex
+        cmake -B "./build.d"
+        cmake --build "./build.d" --target coverage --verbose
+        lcov --capture --base-directory "$PWD" --directory ./build.d --no-external --exclude "$PWD/packcc" --output ./lcov.info
+    - uses: romeovs/lcov-reporter-action@v0.4.0
+      with:
+        lcov-file: ./lcov.info
+        lcov-base: ./lcov.info
+        delete-old-comments: true

--- a/.github/workflows/testing-alpine.yml
+++ b/.github/workflows/testing-alpine.yml
@@ -29,7 +29,7 @@ jobs:
 
       - run: cmake -S . -B build -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_COLOR_MAKEFILE=ON
 
-      - run: cmake --build build --target test_all benchmark
+      - run: cmake --build build --target test
 
 
   release:
@@ -55,7 +55,7 @@ jobs:
 
       - run: cmake -S . -B build -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_COLOR_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Release ${{ matrix.opt }}
 
-      - run: cmake --build build --target benchmark
+      - run: cmake --build build --target test
 
       - run: readelf -h build/pegof
       - run: readelf -d build/pegof

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,4 @@
-name: build and test
+name: Build and test
 
 on:
   push:
@@ -21,6 +21,7 @@ jobs:
       OS: ${{ matrix.os }}
       COMPILER: ${{ matrix.compiler }}
       DEBIAN_FRONTEND: noninteractive
+      CMAKE_BUILD_TYPE: Release
 
     steps:
     - uses: actions/checkout@v4
@@ -32,17 +33,14 @@ jobs:
       run: |
         set -ex
         DEPS=(cmake bats)
-        if [ "$OS" = "ubuntu-24.04" ]; then
-            if [ "$COMPILER" = "g++" ]; then
-                DEPS+=(g++ gcovr lcov uncrustify)
-            else
-                DEPS+=(clang llvm libclang-rt-dev)
-            fi
+        if [ "$COMPILER" = "g++" ]; then
+            DEPS+=(g++)
         else
-            if [ "$COMPILER" = "g++" ]; then
-                DEPS+=(g++)
+            DEPS+=(clang llvm)
+            if [ "$OS" = "ubuntu-24.04" ]; then
+                DEPS+=(libclang-rt-dev)
             else
-                DEPS+=(clang llvm libclang-dev)
+                DEPS+=(libclang-dev)
             fi
         fi
         sudo apt-get update
@@ -55,16 +53,4 @@ jobs:
         cmake --build "./$BUILDDIR" --verbose
     - name: Test
       shell: bash
-      run: |
-        set -ex
-        cmake --build "./$BUILDDIR" --target pegof_test --verbose
-        BUILDDIR=$PWD/$BUILDDIR tests/run.sh
-    - name: Coverage
-      if: ${{ strategy.job-index == 0 && github.event_name != 'push' }}
-      run: lcov --capture --base-directory "$PWD" --directory ./$BUILDDIR --no-external --exclude "$PWD/packcc" --output ./lcov.info
-    - uses: romeovs/lcov-reporter-action@v0.4.0
-      if: ${{ strategy.job-index == 0 && github.event_name != 'push' }}
-      with:
-        lcov-file: ./lcov.info
-        lcov-base: ./lcov.info
-        delete-old-comments: true
+      run: cmake --build "./$BUILDDIR" --target test --verbose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,11 +46,11 @@ target_compile_features(common INTERFACE cxx_std_17)
 add_executable(pegof ${sources})
 target_link_libraries(pegof common)
 
-add_executable(pegof_test ${sources})
-set_target_properties(pegof_test PROPERTIES EXCLUDE_FROM_ALL 1)
-target_compile_options(pegof_test PRIVATE --coverage -g -O0 ${OPTIONAL_DEBUG_OPTIONS})
-target_link_options(pegof_test PRIVATE --coverage ${OPTIONAL_DEBUG_OPTIONS})
-target_link_libraries(pegof_test common)
+add_executable(pegof_coverage ${sources})
+set_target_properties(pegof_coverage PROPERTIES EXCLUDE_FROM_ALL 1)
+target_compile_options(pegof_coverage PRIVATE --coverage -g -O0 ${OPTIONAL_DEBUG_OPTIONS})
+target_link_options(pegof_coverage PRIVATE --coverage ${OPTIONAL_DEBUG_OPTIONS})
+target_link_libraries(pegof_coverage common)
 
 add_custom_command(
     TARGET pegof POST_BUILD
@@ -60,15 +60,22 @@ add_custom_command(
 
 add_custom_target(
     test
-    ${CMAKE_COMMAND} -E env BUILDDIR=${CMAKE_CURRENT_BINARY_DIR} tests/run.sh ${TEST_OPTS}
-    DEPENDS pegof pegof_test
+    ${CMAKE_COMMAND} -E env BUILDDIR=${CMAKE_CURRENT_BINARY_DIR} tests/run.sh
+    DEPENDS pegof
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_custom_target(
     test_all
-    ${CMAKE_COMMAND} -E env BUILDDIR=${CMAKE_CURRENT_BINARY_DIR} INCLUDE_SLOW_TESTS=1 tests/run.sh ${TEST_OPTS}
-    DEPENDS pegof pegof_test
+    ${CMAKE_COMMAND} -E env BUILDDIR=${CMAKE_CURRENT_BINARY_DIR} INCLUDE_SLOW_TESTS=1 tests/run.sh
+    DEPENDS pegof
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(
+    coverage
+    ${CMAKE_COMMAND} -E env BUILDDIR=${CMAKE_CURRENT_BINARY_DIR} PEGOF=${CMAKE_CURRENT_BINARY_DIR}/pegof_coverage tests/coverage.sh
+    DEPENDS pegof_coverage
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,4 @@
+coverage/
 generated.bats
 *.tmp
 *.processed.c

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+if ! which gcovr &> /dev/null; then
+    echo "Error: gcovr is not installed!"
+    exit 1
+fi
+
+cd "$(dirname "$0")/.."
+tests/run.sh
+
+mkdir -p "tests/coverage"
+gcovr -s --calls -e '.*/packcc.c' -r "$PWD" . --html-details="tests/coverage/report.html"
+echo "Coverage report: file://$PWD/tests/coverage/report.html"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -54,7 +54,7 @@ main() {
     export TESTDIR="$(cd "$(dirname "$0")" && pwd)"
     export ROOTDIR="$TESTDIR/.."
     export BUILDDIR="${BUILDDIR:-$ROOTDIR/build}"
-    export PEGOF="${PEGOF:-$BUILDDIR/pegof_test}"
+    export PEGOF="${PEGOF:-$BUILDDIR/pegof}"
     cd "$TESTDIR"
 
     clean
@@ -66,17 +66,7 @@ main() {
     done
 
     echo "Running tests:"
-    set +e # we want coverage even if the tests fail
     bats "$@" ./*.d
-    RESULT=$?
-    set -e
-    if which gcovr &> /dev/null; then
-        cd "$BUILDDIR"
-        mkdir -p "coverage"
-        gcovr -s --calls -e '.*/packcc.c' -r "$ROOTDIR" . --html-details="coverage/report.html"
-        echo "Coverage report: file://$BUILDDIR/coverage/report.html"
-    fi
-    exit $RESULT
 }
 
 main "$@"


### PR DESCRIPTION
Separate the coverage action from tests. This will make both simpler and the testing should be bit faster, since it will use faster executables.